### PR TITLE
Add checksum support to datasets

### DIFF
--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -100,13 +100,15 @@ class DatasetMeta:
     the variable level.
     """
 
-    # the metadata itself
     namespace: Optional[str] = None
     short_name: Optional[str] = None
     title: Optional[str] = None
     description: Optional[str] = None
     sources: List[Source] = field(default_factory=list)
     licenses: List[License] = field(default_factory=list)
+
+    # an md5 checksum of the ingredients used to make this dataset
+    source_checksum: Optional[str] = None
 
     def save(self, filename: str) -> None:
         with open(filename, "w") as ostream:


### PR DESCRIPTION
To support the ability of knowing whether a dataset is out of date, we add two types of checksum support:

- `Dataset.metadata.source_checksum`: record the checksum of the ingredients used to make this dataset
- `Dataset.checksum()`: calculate the checksum of the files in this dataset, if this one is used as an ingredient for another recipe