### PR TITLE
enhance: Version the data catalog API

### DIFF
--- a/owid/catalog/__init__.py
+++ b/owid/catalog/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.1.0"
 
-from .catalogs import Catalog, LocalCatalog, RemoteCatalog, find, find_one  # noqa
+from .catalogs import LocalCatalog, RemoteCatalog, find, find_one  # noqa
 from .datasets import Dataset  # noqa
 from .tables import Table  # noqa
 from .variables import Variable  # noqa


### PR DESCRIPTION
As we change the catalog and metadata format, we will come more and more to situations where someone using the catalog will not be able to read the data, since the API has been updated.

There are multiple approaches we could take, e.g. publishing to a different path per catalog version, but the simplest is simply to publish the catalog with a version number. If the remote catalog's version is newer than your library, it refuses to load and you should update your library version.
