### PR TITLE
enhance: Pack data frames into compact types on Table save

### DIFF
--- a/owid/catalog/frames.py
+++ b/owid/catalog/frames.py
@@ -1,0 +1,135 @@
+#
+#  frames.py
+#  etl
+#
+
+from typing import Any, Dict, List, Optional, Union, cast
+
+import numpy as np
+import pandas as pd
+
+
+def repack_frame(df: pd.DataFrame, remap: Optional[Dict[str, str]] = None) -> None:
+    """
+    Convert the DataFrame's columns to the most compact types possible.
+    Rename columns if necessary during the repacking. The column renames
+    work even if the column is part of the index.
+    """
+    if df.index.names != [None]:
+        raise ValueError("repacking is lost for index columns")
+
+    remap = remap or {}
+
+    # unwind the primary key
+    if len(df.index.names) == 1 and not df.index.names[0]:
+        primary_key = []
+    else:
+        primary_key = cast(List[str], df.index.names)
+        df.reset_index(inplace=True)
+
+    # repack each column into the best dtype we can give it
+    for col in df.columns:
+        df[col] = repack_series(df[col])
+
+    # remap all column names, including those in the primary key
+    for from_, to_ in remap.items():
+        if from_ in df.columns:
+            df.rename(columns={from_: to_}, inplace=True)
+    primary_key = [remap.get(k, k) for k in primary_key]
+
+    assert all(df[col].dtype != "object" for col in df.columns)
+
+    # set the primary key back again
+    if primary_key:
+        df.set_index(primary_key, inplace=True)
+
+
+def repack_series(s: pd.Series) -> pd.Series:
+    if s.dtype.name in ("Int64", "int64", "UInt64", "uint64"):
+        return shrink_integer(s)
+
+    if s.dtype.name in ("object", "float64", "Float64"):
+        for strategy in [to_int, to_float, to_category]:
+            try:
+                return strategy(s)
+            except (ValueError, TypeError):
+                continue
+
+    return s
+
+
+def to_int(s: pd.Series) -> pd.Series:
+    # values could be integers or strings
+    def intify(v: Any) -> Union[int, None]:
+        return int(v) if not pd.isnull(v) else None
+
+    v = cast(pd.Series, s.apply(intify).astype("Int64"))
+
+    if not series_eq(v, s, cast=float):
+        raise ValueError()
+
+    # it's an integer, now pack it smaller
+    return shrink_integer(v)
+
+
+def shrink_integer(s: pd.Series) -> pd.Series:
+    """
+    Take an Int64 series and make it as small as possible.
+    """
+    assert s.dtype.name in ("Int64", "int64", "UInt64", "uint64")
+
+    if s.isnull().any():
+        if s.min() < 0:
+            series = ["Int32", "Int16", "Int8"]
+        else:
+            series = ["UInt32", "UInt16", "UInt8"]
+    else:
+        if s.min() < 0:
+            series = ["int32", "int16", "int8"]
+        else:
+            series = ["uint32", "uint16", "uint8"]
+
+    for dtype in series:
+        v = s.astype(dtype)
+        if not (v == s).all():
+            break
+
+        s = v
+
+    return s
+
+
+def to_float(s: pd.Series) -> pd.Series:
+    options = ["float32", "float64"]
+    for dtype in options:
+        v = s.astype(dtype)
+
+        if series_eq(s, v, float):
+            return v
+
+    raise ValueError()
+
+
+def to_category(s: pd.Series) -> pd.Series:
+    types = set(s.dropna().apply(type).unique())
+
+    if types.difference({str, type(None)}):
+        raise ValueError()
+
+    return s.astype("category")
+
+
+def series_eq(
+    lhs: pd.Series, rhs: pd.Series, cast: Any, rtol: float = 1e-5, atol: float = 1e-8
+) -> bool:
+    """
+    Check that series are equal, but unlike normal floating point checks where
+    NaN != NaN, we want missing or null values to be reported as equal to each
+    other.
+    """
+    if len(lhs) != len(rhs) or (lhs.isnull() != rhs.isnull()).any():
+        return False
+
+    lhs_values = lhs.dropna().apply(cast)
+    rhs_values = rhs.dropna().apply(cast)
+    return np.allclose(lhs_values, rhs_values, rtol=rtol, atol=atol)

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -12,6 +12,7 @@ import requests
 
 from . import variables
 from .meta import VariableMeta, TableMeta
+from .frames import repack_frame
 
 SCHEMA = json.load(open(join(dirname(__file__), "schemas", "table.json")))
 METADATA_FIELDS = list(SCHEMA["properties"])
@@ -75,6 +76,7 @@ class Table(pd.DataFrame):
     def to_feather(
         self,
         path: Any,
+        repack: bool = True,
         compression: Literal["zstd", "lz4", "uncompressed"] = "zstd",
         **kwargs: Any,
     ) -> None:
@@ -90,6 +92,10 @@ class Table(pd.DataFrame):
         df = pd.DataFrame(self)
         if self.primary_key:
             df = df.reset_index()
+
+        if repack:
+            # use smaller data types wherever possible
+            repack_frame(df)
 
         df.to_feather(path, compression=compression, **kwargs)
 

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1,0 +1,201 @@
+#
+#  test_frames.py
+#
+
+
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+import pytest
+
+from owid.catalog import frames
+
+
+def test_repack_non_object_columns():
+    df = pd.DataFrame(
+        {"myint": [1, 2, 3], "myfloat": [1.0, 2.2, 3.0], "mycat": ["a", "b", "c"]}
+    )
+    df["mycat"] = df["mycat"].astype("category")
+
+    df2 = df.copy()
+    frames.repack_frame(df2, {})
+
+    assert df2.myint.dtype.name == "uint8"
+    assert df2.myfloat.dtype.name == "float32"
+    assert_frame_equal(df, df2, check_dtype=False)
+
+
+def test_repack_object_columns():
+    df = pd.DataFrame(
+        {
+            "myint": [1, 2, None, 3],
+            "myfloat": [1.2, 2.0, 3.0, None],
+            "mycat": ["a", None, "b", "c"],
+        },
+        dtype="object",
+    )
+
+    df_repack = df.copy()
+
+    frames.repack_frame(df_repack)
+    assert df_repack.myint.dtype.name == "UInt8"
+    assert df_repack.myfloat.dtype.name == "float32"
+    assert df_repack.mycat.dtype.name == "category"
+
+
+def test_repack_frame_with_index():
+    df = pd.DataFrame(
+        {
+            "myint": [1, 2, None, 3],
+            "myfloat": [1.2, 2.0, 3.0, None],
+            "mycat": ["a", None, "b", "c"],
+        },
+        dtype="object",
+    )
+    df.set_index(["myint", "mycat"], inplace=True)
+
+    with pytest.raises(ValueError):
+        frames.repack_frame(df)
+
+
+def test_repack_integer_strings():
+    s = pd.Series(["1", "2", "3", None])
+    v = frames.repack_series(s)
+    assert v.dtype.name == "UInt8"
+
+
+def test_repack_float_strings():
+    s = pd.Series(["10", "22.2", "30"])
+    v = frames.repack_series(s)
+    assert v.dtype.name == "float32"
+
+
+def test_repack_uint64():
+    s = pd.Series([10, 20], dtype="uint64")
+    v = frames.repack_series(s)
+    assert v.dtype.name == "uint8"
+
+
+def test_repack_int8_boundaries():
+    s = pd.Series([0, -1])
+    info = np.iinfo(np.int8)
+
+    # check the lower boundary
+    s[0] = info.min
+    assert frames.repack_series(s).dtype.name == "int8"
+    s[0] -= 1
+    assert frames.repack_series(s).dtype.name == "int16"
+
+    # check the upper boundary
+    s[0] = info.max
+    assert frames.repack_series(s).dtype.name == "int8"
+    s[0] += 1
+    assert frames.repack_series(s).dtype.name == "int16"
+
+
+def test_repack_int16_boundaries():
+    s = pd.Series([0, -1])
+    info = np.iinfo(np.int16)
+
+    # check the lower boundary
+    s[0] = info.min
+    assert frames.repack_series(s).dtype.name == "int16"
+    s[0] -= 1
+    assert frames.repack_series(s).dtype.name == "int32"
+
+    # check the upper boundary
+    s[0] = info.max
+    assert frames.repack_series(s).dtype.name == "int16"
+    s[0] += 1
+    assert frames.repack_series(s).dtype.name == "int32"
+
+
+def test_repack_int32_boundaries():
+    s = pd.Series([0, -1])
+    info = np.iinfo(np.int32)
+
+    # check the lower boundary
+    s[0] = info.min
+    assert frames.repack_series(s).dtype.name == "int32"
+    s[0] -= 1
+    assert frames.repack_series(s).dtype.name == "int64"
+
+    # check the upper boundary
+    s[0] = info.max
+    assert frames.repack_series(s).dtype.name == "int32"
+    s[0] += 1
+    assert frames.repack_series(s).dtype.name == "int64"
+
+
+def test_repack_uint_boundaries():
+    s = pd.Series([0])
+    # uint8
+    info = np.iinfo(np.uint8)
+    s[0] = info.max
+    assert frames.repack_series(s).dtypes.name == "uint8"
+
+    s[0] += 1
+    assert frames.repack_series(s).dtypes.name == "uint16"
+
+    # uint16
+    info = np.iinfo(np.uint16)
+    s[0] = info.max
+    assert frames.repack_series(s).dtypes.name == "uint16"
+
+    s[0] += 1
+    assert frames.repack_series(s).dtypes.name == "uint32"
+
+    # uint32
+    info = np.iinfo(np.uint32)
+    s[0] = info.max
+    assert frames.repack_series(s).dtypes.name == "uint32"
+
+    # we don't bother using uint64, we just use int64
+    s[0] += 1
+    assert frames.repack_series(s).dtypes.name == "int64"
+
+
+def test_repack_int():
+    s = pd.Series([1, 2, None, 3]).astype("object")
+    v = frames.repack_series(s)
+    assert v.dtype == "UInt8"
+
+
+def test_repack_int_no_null():
+    s = pd.Series([1, 2, 3]).astype("object")
+    v = frames.repack_series(s)
+    assert v.dtype == "uint8"
+
+
+def test_repack_float_to_int():
+    s = pd.Series([1, 2, None, 3])
+    assert s.dtype == "float64"
+    v = frames.repack_series(s)
+    assert v.dtype == "UInt8"
+
+
+def test_repack_float_object_to_float32():
+    s = pd.Series([1, 2, None, 3.3], dtype="object")
+
+    v = frames.repack_series(s)
+    assert v.dtype == "float32"
+
+
+def test_repack_category():
+    s = pd.Series(["a", "b", "c", None])
+    assert s.dtype == np.object_
+
+    v = frames.repack_series(s)
+    assert v.dtype == "category"
+
+
+def test_shrink_integers_uint8():
+    s = pd.Series([1, 2, 3], dtype="Int64")
+    v = frames.shrink_integer(s)
+    assert v.dtype.name == "uint8"
+
+
+def test_shrink_integers_int8():
+    s = pd.Series([1, 2, 3, -3], dtype="Int64")
+    v = frames.shrink_integer(s)
+    assert v.dtype.name == "int8"


### PR DESCRIPTION
This PR causes `Table.to_feather()` to modify data types on save to the most compact types possible. For example, small numbers may be converted from `int64` to `int8` or `uint8`. The conversion is opt-out, meaning it is applied by default.