### PR TITLE
fix #21: allow loading from local catalogs

### DIFF
--- a/owid/catalog/__init__.py
+++ b/owid/catalog/__init__.py
@@ -1,7 +1,22 @@
 __version__ = "0.1.0"
 
-from .catalogs import LocalCatalog, RemoteCatalog, find, find_one  # noqa
-from .datasets import Dataset  # noqa
-from .tables import Table  # noqa
-from .variables import Variable  # noqa
-from .meta import DatasetMeta, TableMeta, VariableMeta, Source, License  # noqa
+from .catalogs import LocalCatalog, RemoteCatalog, find, find_one
+from .datasets import Dataset
+from .tables import Table
+from .variables import Variable
+from .meta import DatasetMeta, TableMeta, VariableMeta, Source, License
+
+__all__ = [
+    "LocalCatalog",
+    "RemoteCatalog",
+    "find",
+    "find_one",
+    "Dataset",
+    "Table",
+    "Variable",
+    "DatasetMeta",
+    "TableMeta",
+    "VariableMeta",
+    "Source",
+    "License",
+]

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -2,7 +2,7 @@
 #  datasets.py
 #
 
-from os.path import join, isdir, exists
+from os.path import join, exists
 from os import mkdir
 from dataclasses import dataclass
 import shutil
@@ -39,19 +39,21 @@ class Dataset:
 
     @classmethod
     def create_empty(
-        cls, path: str, metadata: Optional["DatasetMeta"] = None
+        cls, path: Union[str, Path], metadata: Optional["DatasetMeta"] = None
     ) -> "Dataset":
-        if isdir(path):
-            if not exists(join(path, "index.json")):
+        path = Path(path)
+
+        if path.is_dir():
+            if not (path / "index.json").exists():
                 raise Exception(f"refuse to overwrite non-dataset dir at: {path}")
             shutil.rmtree(path)
 
         mkdir(path)
 
-        index_file = join(path, "index.json")
+        index_file = path / "index.json"
         DatasetMeta().save(index_file)
 
-        return Dataset(path)
+        return Dataset(path.as_posix())
 
     def add(
         self, table: tables.Table, format: Literal["csv", "feather"] = "feather"

--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -4,8 +4,8 @@
 #  Metadata helpers.
 #
 
-
-from typing import Optional, TypeVar, Dict, Any, List
+from pathlib import Path
+from typing import Optional, TypeVar, Dict, Any, List, Union
 from dataclasses import dataclass, field
 import json
 
@@ -97,7 +97,8 @@ class DatasetMeta:
     # an md5 checksum of the ingredients used to make this dataset
     source_checksum: Optional[str] = None
 
-    def save(self, filename: str) -> None:
+    def save(self, filename: Union[str, Path]) -> None:
+        filename = Path(filename).as_posix()
         with open(filename, "w") as ostream:
             json.dump(self.to_dict(), ostream, indent=2)
 

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -2,10 +2,16 @@
 #  test_catalogs.py
 #
 
-from typing import Optional
+import tempfile
+from typing import Optional, Iterator
+from contextlib import contextmanager
+from pathlib import Path
 
-from owid.catalog.catalogs import RemoteCatalog
-from owid.catalog.tables import Table
+import pytest  # noqa
+
+from owid.catalog import RemoteCatalog, LocalCatalog, Table
+
+from .test_datasets import create_temp_dataset
 
 
 _catalog: Optional[RemoteCatalog] = None
@@ -33,3 +39,23 @@ def test_remote_find_one():
     c = load_catalog()
     t = c.find_one("population", dataset="key_indicators", namespace="owid")
     assert isinstance(t, Table)
+
+
+def test_find_from_local_catalog():
+    with mock_catalog(3) as catalog:
+        matches = catalog.find()
+        assert len(matches.dataset.unique()) == 3
+
+
+def test_load_from_local_catalog():
+    with mock_catalog(1) as catalog:
+        catalog.find().iloc[0].load()
+
+
+@contextmanager
+def mock_catalog(n: int = 3) -> Iterator[LocalCatalog]:
+    with tempfile.TemporaryDirectory() as dirname:
+        path = Path(dirname)
+        for i in range(n):
+            create_temp_dataset(path / f"dataset{i}")
+        yield LocalCatalog(path)


### PR DESCRIPTION
A `LocalCatalog` is just a folder full of datasets, themselves just folders full of tables. Some of the nice catalog interface only got tested for the `RemoteCatalog`, and remained broken locally.

The `LocalCatalog()` would firstly not correctly work unless it had been indexed. Secondly, it would fail on `load()` of a table because the `_base_uri` had not been set.

This fix automatically reindexes a local catalog if no index is present, and secondly fixes the load method so that you can properly load local datasets.
