### PR TITLE
enhance(grapher): align metadata for grapher and ETL

### DIFF
--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -144,7 +144,7 @@ class DatasetMeta:
         return None
 
     def update_from_yaml(self, path: Union[Path, str]) -> None:
-        """Update metadata from a YAML file."""
+        """The main reason for wanting to do this is to manually override what goes into Grapher before an export."""
         with open(path) as istream:
             annot = yaml.safe_load(istream)
 


### PR DESCRIPTION
Add fields `published_by` and `publisher_source` to `Source` object which are necessary to get parity between ETL and grapher. In the future when we refine grapher data model we might consolidate these, but for the time being this is the easiest option.

Also add helper functions for loading metadata from yaml files. This is still proof-of-concept, if we decide it's a good idea we'll refactor it and add more tests & validations (gonna create a task for that).

`underscore` function was improved to handle columns from WB dataset, but that one is also good candidate for future refactoring.