### PR TITLE
fix(metadata): fix lost metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ ds_new = Dataset('/tmp/new_data_path')
 
 Tables are essentially pandas DataFrames but with metadata. All operations on them occur in-memory, except for loading from and saving to disk. On disk, they are represented by tabular file (feather or CSV) and a JSON metadata file.
 
+Columns of `Table` have attribute `VariableMeta`, including their type, description, and unit. Be carful when manipulating them, not all operations are currently supported. Supported are: adding a column, renaming columns. Not supported: direct assignment to `t.columns = ...` or to index names `t.columns.index = ...`.
+
 #### Make a new table
 
 ```python
@@ -193,6 +195,7 @@ t = Table.read_csv('/tmp/my_table.csv')
   - Add flag `is_public` for public/private datasets
   - Enforce snake_case for table, dataset and variable short names
   - Add fields `published_by` and `published_at` to Source
+  - Added a list of supported and unsupported operations on columns
 - `v0.2.5`
   - Fix ability to load remote CSV tables
 - `v0.2.4`

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -51,8 +51,10 @@ class Dataset:
 
         mkdir(path)
 
+        metadata = metadata or DatasetMeta()
+
         index_file = path / "index.json"
-        DatasetMeta().save(index_file)
+        metadata.save(index_file)
 
         return Dataset(path.as_posix())
 

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -4,6 +4,7 @@
 
 from os.path import join, dirname, splitext
 import json
+import copy
 from typing import Any, Literal, Optional, List, Dict, Union, cast
 from collections import defaultdict
 
@@ -242,6 +243,8 @@ class Table(pd.DataFrame):
 
         if kwargs.get("inplace"):
             new_table = self
+        else:
+            new_table._fields = copy.deepcopy(self._fields)
 
         # rename metadata for changed columns
         for old_col, new_col in zip(old_cols, new_table.columns):

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -235,7 +235,7 @@ class Table(pd.DataFrame):
         "mapper",
         [("copy", True), ("inplace", False), ("level", None), ("errors", "ignore")],
     )
-    def rename(self, *args, **kwargs) -> Optional["Table"]:
+    def rename(self, *args: Any, **kwargs: Any) -> Optional["Table"]:
         """Rename columns while keeping their metadata."""
         old_cols = self.columns
         new_table = super().rename(*args, **kwargs)

--- a/owid/catalog/utils.py
+++ b/owid/catalog/utils.py
@@ -1,10 +1,11 @@
 import re
 from typing import Optional
+from unidecode import unidecode
 
 from .tables import Table
 
 
-def underscore(name: Optional[str]) -> Optional[str]:
+def underscore(name: Optional[str], validate: bool = True) -> Optional[str]:
     """Convert arbitrary string to under_score. This was fine tuned on WDI bank column names.
     This function might evolve in the future, so make sure to have your use cases in tests
     or rather underscore your columns yourself.
@@ -20,14 +21,19 @@ def underscore(name: Optional[str]) -> Optional[str]:
         .lower()
     )
 
-    # replace parantheses with __
-    name = name.replace("(", "__").replace(")", "__")
+    # replace special separators
+    name = (
+        name.replace("(", "__").replace(")", "__").replace(":", "__").replace(";", "__")
+    )
 
     # replace special symbols
+    name = name.replace("/", "_")
+    name = name.replace("=", "_")
     name = name.replace("%", "pct")
     name = name.replace("+", "plus")
     name = name.replace("us$", "usd")
     name = name.replace("$", "dollar")
+    name = name.replace("&", "_and_")
 
     # replace quotes
     name = name.replace("'", "")
@@ -35,25 +41,31 @@ def underscore(name: Optional[str]) -> Optional[str]:
     # shrink triple underscore
     name = re.sub("__+", "__", name)
 
+    # convert special characters to ASCII
+    name = unidecode(name)
+
     # strip leading and trailing underscores
     name = name.strip("_")
 
     # make sure it's under_score now, if not then raise NameError
-    validate_underscore(name, "Name")
+    if validate:
+        validate_underscore(name, "Name")
 
     return name
 
 
 def underscore_table(t: Table) -> Table:
     """Convert column and index names to underscore."""
-    t.columns = [underscore(e) for e in t.columns]
+    t = t.rename(columns=underscore)
+
     t.index.names = [underscore(e) for e in t.index.names]
+    t.metadata.primary_key = t.index.names  # type: ignore
     return t
 
 
 def validate_underscore(name: Optional[str], object_name: str) -> None:
     """Raise error if name is not snake_case."""
-    if name is not None and not re.match("^[a-z][a-z0-9_]+$", name):
+    if name is not None and not re.match("^[a-z][a-z0-9_]*$", name):
         raise NameError(
-            f"{object_name} must be snake_case. Change `{name}` to `{underscore(name)}`"
+            f"{object_name} must be snake_case. Change `{name}` to `{underscore(name, validate=False)}`"
         )

--- a/owid/catalog/utils.py
+++ b/owid/catalog/utils.py
@@ -59,7 +59,7 @@ def underscore_table(t: Table) -> Table:
     t = t.rename(columns=underscore)
 
     t.index.names = [underscore(e) for e in t.index.names]
-    t.metadata.primary_key = t.index.names  # type: ignore
+    t.metadata.primary_key = t.index.names
     return t
 
 

--- a/owid/catalog/utils.py
+++ b/owid/catalog/utils.py
@@ -59,7 +59,7 @@ def underscore_table(t: Table) -> Table:
     t = t.rename(columns=underscore)
 
     t.index.names = [underscore(e) for e in t.index.names]
-    t.metadata.primary_key = t.index.names
+    t.metadata.primary_key = t.primary_key
     return t
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -711,6 +711,14 @@ mypy-extensions = ">=0.3.0"
 typing-extensions = ">=3.7.4"
 
 [[package]]
+name = "unidecode"
+version = "1.3.4"
+description = "ASCII transliterations of Unicode text"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "urllib3"
 version = "1.26.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -745,7 +753,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5285d2ffdf82bed17aec095ec1cc6708395beb3b2a62339160a1e635e591c972"
+content-hash = "18fbdf4aefc96a423f03f55592ecd8e13d314aaf36b46e8a446cd10c1c9f6b04"
 
 [metadata.files]
 appnope = [
@@ -1194,6 +1202,10 @@ typing-inspect = [
     {file = "typing_inspect-0.7.1-py2-none-any.whl", hash = "sha256:b1f56c0783ef0f25fb064a01be6e5407e54cf4a4bf4f3ba3fe51e0bd6dcea9e5"},
     {file = "typing_inspect-0.7.1-py3-none-any.whl", hash = "sha256:3cd7d4563e997719a710a3bfe7ffb544c6b72069b6812a02e9b414a8fa3aaa6b"},
     {file = "typing_inspect-0.7.1.tar.gz", hash = "sha256:047d4097d9b17f46531bf6f014356111a1b6fb821a24fe7ac909853ca2a782aa"},
+]
+unidecode = [
+    {file = "Unidecode-1.3.4-py3-none-any.whl", hash = "sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257"},
+    {file = "Unidecode-1.3.4.tar.gz", hash = "sha256:8e4352fb93d5a735c788110d2e7ac8e8031eb06ccbfe8d324ab71735015f9342"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ ipdb = "^0.13.9"
 pytest-cov = "^2.12.1"
 requests = "^2.26.0"
 boto3 = "^1.21.13"
+Unidecode = "^1.3.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -38,6 +38,11 @@ def test_create_empty():
         assert doc == {"is_public": True}
 
 
+def test_create_empty_with_metadata(tmpdir):
+    ds = Dataset.create_empty(tmpdir / "dataset", DatasetMeta(namespace="test"))
+    assert ds.metadata.namespace == "test"
+
+
 def test_create_fails_if_non_dataset_dir_exists():
     with temp_dataset_dir(create=True) as dirname:
         with pytest.raises(Exception):

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -18,7 +18,7 @@ def test_repack_non_object_columns():
     df["mycat"] = df["mycat"].astype("category")
 
     df2 = df.copy()
-    frames.repack_frame(df2, {})
+    df2 = frames.repack_frame(df2, {})
 
     assert df2.myint.dtype.name == "uint8"
     assert df2.myfloat.dtype.name == "float32"
@@ -37,7 +37,7 @@ def test_repack_object_columns():
 
     df_repack = df.copy()
 
-    frames.repack_frame(df_repack)
+    df_repack = frames.repack_frame(df_repack)
     assert df_repack.myint.dtype.name == "UInt8"
     assert df_repack.myfloat.dtype.name == "float32"
     assert df_repack.mycat.dtype.name == "category"

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -254,3 +254,19 @@ def test_load_csv_table_over_http() -> None:
     Table.read_csv(
         "http://owid-catalog.nyc3.digitaloceanspaces.com/reference/countries_regions.csv"
     )
+
+
+def test_rename_columns() -> None:
+    t = mock_table()
+    t.gdp.metadata.title = "GDP"
+    t = t.rename(columns={"gdp": "new_gdp"})
+    assert t.new_gdp.metadata.title == "GDP"
+    assert t.columns == ["new_gdp"]
+
+
+def test_rename_columns_inplace() -> None:
+    t = mock_table()
+    t.gdp.metadata.title = "GDP"
+    t.rename(columns={"gdp": "new_gdp"}, inplace=True)
+    assert t.new_gdp.metadata.title == "GDP"
+    assert t.columns == ["new_gdp"]

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -257,15 +257,22 @@ def test_load_csv_table_over_http() -> None:
 
 
 def test_rename_columns() -> None:
-    t = mock_table()
+    t: Table = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "CH"]}).set_index(
+        "country"
+    )  # type: ignore
     t.gdp.metadata.title = "GDP"
-    t = t.rename(columns={"gdp": "new_gdp"})
-    assert t.new_gdp.metadata.title == "GDP"
-    assert t.columns == ["new_gdp"]
+    new_t = t.rename(columns={"gdp": "new_gdp"})
+    assert new_t.new_gdp.metadata.title == "GDP"
+    assert new_t.columns == ["new_gdp"]
+
+    # old table hasn't changed
+    assert t.gdp.metadata.title == "GDP"
 
 
 def test_rename_columns_inplace() -> None:
-    t = mock_table()
+    t: Table = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "CH"]}).set_index(
+        "country"
+    )  # type: ignore
     t.gdp.metadata.title = "GDP"
     t.rename(columns={"gdp": "new_gdp"}, inplace=True)
     assert t.new_gdp.metadata.title == "GDP"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from owid.catalog.utils import underscore
+import pandas as pd
+from owid.catalog import Table
+from owid.catalog.utils import underscore, underscore_table
 
 
 def test_underscore():
@@ -30,3 +32,42 @@ def test_underscore():
         underscore("Automated teller machines (ATMs) (per 100,000 adults)")
         == "automated_teller_machines__atms__per_100_000_adults"
     )
+    assert (
+        underscore(
+            "Political regimes - OWID based on Boix et al. (2013), V-Dem (v12), and Lührmann et al. (2018)"
+        )
+        == "political_regimes__owid_based_on_boix_et_al__2013__v_dem__v12__and_luhrmann_et_al__2018"
+    )
+    assert (
+        underscore("Adjusted savings: particulate emission damage (current US$)")
+        == "adjusted_savings__particulate_emission_damage__current_usd"
+    )
+    assert (
+        underscore(
+            "Benefit incidence of unemployment benefits and ALMP to poorest quintile (% of total U/ALMP benefits)"
+        )
+        == "benefit_incidence_of_unemployment_benefits_and_almp_to_poorest_quintile__pct_of_total_u_almp_benefits"
+    )
+    assert (
+        underscore(
+            "Business extent of disclosure index (0=less disclosure to 10=more disclosure)"
+        )
+        == "business_extent_of_disclosure_index__0_less_disclosure_to_10_more_disclosure"
+    )
+    assert (
+        underscore("Firms that spend on R&D (% of firms)")
+        == "firms_that_spend_on_r_and_d__pct_of_firms"
+    )
+
+
+def test_underscore_table():
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    df.index.names = ["I"]
+
+    t = Table(df)
+    t["A"].metadata.description = "column A"
+
+    tt = underscore_table(t)
+    assert tt.columns == ["a"]
+    assert tt.index.names == ["i"]
+    assert tt["a"].metadata.description == "column A"


### PR DESCRIPTION
I've found that we're losing metadata on several places when manipulating with columns. I fixed what I could and added mention to README. Some operations like `t.columns = ...` might be non-trivial to do, but at least we're aware of it now.