### PR TITLE
typing.Literal is available from python version 3.8, so I have replac…

### DIFF
--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -6,7 +6,7 @@ from os.path import join, exists
 from os import mkdir
 from dataclasses import dataclass
 import shutil
-from typing import Any, Iterator, List, Literal, Optional, Union
+from typing import Any, Iterator, List, Optional, Union
 from glob import glob
 import hashlib
 from pathlib import Path
@@ -19,6 +19,10 @@ from .properties import metadata_property
 from .meta import DatasetMeta, TableMeta
 from . import utils
 
+try:
+     from typing import Literal
+except ImportError:
+     from typing_extensions import Literal
 
 @dataclass
 class Dataset:

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -6,7 +6,7 @@ from os.path import join, dirname, splitext
 import json
 import copy
 import yaml
-from typing import Any, Literal, Optional, List, Dict, Union, cast
+from typing import Any, Optional, List, Dict, Union, cast
 from collections import defaultdict
 from pathlib import Path
 
@@ -20,6 +20,12 @@ from .frames import repack_frame
 from pandas.util._decorators import (
     rewrite_axis_style_signature,
 )
+
+try:
+     from typing import Literal
+except ImportError:
+     from typing_extensions import Literal
+
 
 SCHEMA = json.load(open(join(dirname(__file__), "schemas", "table.json")))
 METADATA_FIELDS = list(SCHEMA["properties"])


### PR DESCRIPTION
typing.Literal is available from python version 3.8, so I have replace it in case of old versions from typing_extensions


change "from typing import Literal" from all files into:
```python

try:
     from typing import Literal
except ImportError:
     from typing_extensions import Literal
```
This is help users with old versions of python to work without any error as one that I have faced.