### PR TITLE
fix(underscore): keep metadata when resolving collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ t = Table.read_csv('/tmp/my_table.csv')
   - Optional `repack` argument when adding tables to dataset
   - Underscore `|`
   - Get `version` field from `DatasetMeta` init
+  - Resolve collisions of `underscore_table` function
 - `v0.2.9`
   - Allow multiple channels in `catalog.find` function
 - `v0.2.8`

--- a/owid/catalog/utils.py
+++ b/owid/catalog/utils.py
@@ -123,9 +123,11 @@ def underscore_table(
     to control whether to raise an error or append numbered suffix."""
     orig_cols = t.columns
 
-    t = t.rename(columns=underscore)
+    # underscore columns and resolve collisions
+    new_cols = pd.Index([underscore(c) for c in t.columns])
+    new_cols = _resolve_collisions(orig_cols, new_cols, collision)
 
-    t.columns = _resolve_collisions(orig_cols, t.columns, collision)
+    t = t.rename(columns={c_old: c_new for c_old, c_new in zip(orig_cols, new_cols)})
 
     t.index.names = [underscore(e) for e in t.index.names]
     t.metadata.primary_key = t.primary_key

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,6 +110,10 @@ def test_underscore_table():
 def test_underscore_table_collision():
     df = pd.DataFrame({"A__x": [1, 2, 3], "B": [1, 2, 3], "A(x)": [1, 2, 3]})
     t = Table(df)
+    t["A__x"].metadata.description = "desc1"
+    t["B"].metadata.description = "desc2"
+    t["A(x)"].metadata.description = "desc3"
+
     # raise error by default
     with pytest.raises(NameError):
         underscore_table(t)
@@ -117,3 +121,8 @@ def test_underscore_table_collision():
     # add suffix
     tt = underscore_table(t, collision="rename")
     assert list(tt.columns) == ["a__x_1", "b", "a__x_2"]
+
+    # make sure we retain metadata
+    assert tt["a__x_1"].metadata.description == "desc1"
+    assert tt["b"].metadata.description == "desc2"
+    assert tt["a__x_2"].metadata.description == "desc3"


### PR DESCRIPTION
The original approach with `t.columns = ...` dropped metadata of colliding columns. Using `.rename(columns=` fixes that.