### PR TITLE
feature(reindex): add `include` arg

### DIFF
--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -19,7 +19,7 @@ def pruned_json(cls: T) -> T:
     orig = cls.to_dict  # type: ignore
 
     # only keep non-null public variables
-    cls.to_dict = lambda self: {  # type: ignore
+    cls.to_dict = lambda self, orig=orig: {  # type: ignore
         k: v
         for k, v in orig(self).items()
         if not k.startswith("_") and v not in [None, [], {}]

--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -19,7 +19,7 @@ def pruned_json(cls: T) -> T:
     orig = cls.to_dict  # type: ignore
 
     # only keep non-null public variables
-    cls.to_dict = lambda self, orig=orig: {  # type: ignore
+    cls.to_dict = lambda self: {  # type: ignore
         k: v
         for k, v in orig(self).items()
         if not k.startswith("_") and v not in [None, [], {}]

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -77,6 +77,28 @@ def test_calling_find_adds_channels():
     assert set(REMOTE_CATALOG.channels) == {"garden", "meadow"}  # type: ignore
 
 
+def test_reindex_with_include():
+    with mock_catalog(3, channels=("garden",)) as catalog:
+        old_frame = catalog.frame.copy()
+
+        # create new dataset0
+        create_temp_dataset(catalog.path / "garden" / "dataset0")
+
+        # reindex
+        catalog.reindex(include="dataset0")
+        new_frame = catalog.frame
+
+        # and make sure we have a new checksum for dataset0
+        assert set(old_frame[old_frame.dataset == "dataset0"].checksum) != set(
+            new_frame[new_frame.dataset == "dataset0"].checksum
+        )
+
+        # and same checksum for others
+        assert set(old_frame[old_frame.dataset != "dataset0"].checksum) == set(
+            new_frame[new_frame.dataset != "dataset0"].checksum
+        )
+
+
 @contextmanager
 def mock_catalog(
     n: int = 3, channels: Iterable[CHANNEL] = ("garden",)


### PR DESCRIPTION
Reindexing of an entire catalog is slow (~10s) which is fine for bulk updates, but slow for fast-track. Add `include` argument to only reindex datasets matching given pattern and reuse all the other datasets from existing catalog.