### PR TITLE
fix(meta): fix to_json for dataclasses

### DIFF
--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -19,9 +19,9 @@ def pruned_json(cls: T) -> T:
     orig = cls.to_dict  # type: ignore
 
     # only keep non-null public variables
-    cls.to_dict = lambda self: {  # type: ignore
+    cls.to_dict = lambda self, **kwargs: {  # type: ignore
         k: v
-        for k, v in orig(self).items()
+        for k, v in orig(self, **kwargs).items()
         if not k.startswith("_") and v not in [None, [], {}]
     }
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -38,3 +38,7 @@ def test_dataset_version():
     assert meta.DatasetMeta(sources=[s1]).version == "2022-01-01"
     assert meta.DatasetMeta(sources=[s1, s2]).version is None
     assert meta.DatasetMeta(version="1", sources=[s1]).version == "1"
+
+
+def test_to_json():
+    meta.Source(name="s1", publication_date="2022-01-01").to_json()  # type: ignore


### PR DESCRIPTION
dataclass_json is passing an extra `encode_json` argument that is breaking `to_json`