### PR TITLE
refactor(explorers): remove mention of deprecated explorer channel

### DIFF
--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -37,9 +37,8 @@ S3_OWID_URI = "s3://owid-catalog"
 REMOTE_CATALOG: Optional["RemoteCatalog"] = None
 
 # available channels in the catalog
-# NOTE: channel `explorer` was deprecated, remove it once we merge new food explorer in the correct explorers channel
 CHANNEL = Literal[
-    "garden", "meadow", "backport", "open_numbers", "examples", "explorer", "explorers"
+    "garden", "meadow", "backport", "open_numbers", "examples", "explorers"
 ]
 
 


### PR DESCRIPTION
Remove mention of deprecated `explorer` channel in catalog.
Is there any other change to be made with this regard?
