### PR TITLE
feature: add parquet support and render to multiple files

### DIFF
--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -186,10 +186,10 @@ class Dataset:
         return join(self.path, "index.json")
 
     def __len__(self) -> int:
-        return len(self._table_names)
+        return len(self.table_names)
 
     def __iter__(self) -> Iterator[tables.Table]:
-        for name in self._table_names:
+        for name in self.table_names:
             yield self[name]
 
     @property
@@ -200,13 +200,8 @@ class Dataset:
         return sorted(glob(feather_pattern) + glob(parquet_pattern) + glob(csv_pattern))
 
     @property
-    def _table_names(self) -> List[str]:
-        return sorted(set(Path(f).stem for f in self._data_files))
-
-    @property
     def table_names(self) -> List[str]:
-        """Return table names available in the dataset."""
-        return [Path(f).stem for f in self._data_files]
+        return sorted(set(Path(f).stem for f in self._data_files))
 
     @property
     def _metadata_files(self) -> List[str]:

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -94,8 +94,11 @@ class Dataset:
             elif format == "parquet":
                 table.to_parquet(table_filename, repack=repack)
 
-            else:
+            elif format == "csv":
                 table.to_csv(table_filename)
+
+            else:
+                raise ValueError(f"Unknown format: {format}")
 
     def __getitem__(self, name: str) -> tables.Table:
         stem = self.path / Path(name)

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -21,7 +21,7 @@ from .meta import DatasetMeta, TableMeta
 from . import utils
 
 ALLOWED_FORMATS = ["csv", "feather", "parquet"]
-DEFAULT_FORMATS = ["csv", "feather", "parquet"]
+DEFAULT_FORMATS = ["feather", "parquet"]
 
 
 @dataclass

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -7,7 +7,7 @@ from os import mkdir
 from dataclasses import dataclass
 import shutil
 import warnings
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Iterator, List, Literal, Optional, Union
 from glob import glob
 import hashlib
 from pathlib import Path
@@ -20,8 +20,9 @@ from .properties import metadata_property
 from .meta import DatasetMeta, TableMeta
 from . import utils
 
-ALLOWED_FORMATS = ["csv", "feather", "parquet"]
-DEFAULT_FORMATS = ["feather", "parquet"]
+FileFormat = Literal["csv", "feather", "parquet"]
+ALLOWED_FORMATS: List[FileFormat] = ["csv", "feather", "parquet"]
+DEFAULT_FORMATS: List[FileFormat] = ["feather", "parquet"]
 
 
 @dataclass
@@ -65,7 +66,7 @@ class Dataset:
     def add(
         self,
         table: tables.Table,
-        formats: List[str] = DEFAULT_FORMATS,
+        formats: List[FileFormat] = DEFAULT_FORMATS,
         repack: bool = True,
     ) -> None:
         """Add this table to the dataset by saving it in the dataset's folder. Defaults to

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -11,6 +11,8 @@ from collections import defaultdict
 from pathlib import Path
 
 import pandas as pd
+import pyarrow
+import pyarrow.parquet as pq
 import requests
 
 from . import variables
@@ -115,21 +117,50 @@ class Table(pd.DataFrame):
         metadata_filename = splitext(path)[0] + ".meta.json"
         self._save_metadata(metadata_filename)
 
+    def to_parquet(self, path: Any, repack: bool = True) -> None:  # type: ignore
+        """
+        Save this table as a parquet file with embedded metadata in the table schema.
+        """
+        if not isinstance(path, str) or not path.endswith(".parquet"):
+            raise ValueError(f'filename must end in ".parquet": {path}')
+
+        if repack:
+            # use smaller data types wherever possible
+            # NOTE: this can be slow for large dataframes
+            df = pd.DataFrame(self)
+        else:
+            df = self
+
+        # create a pyarrow table with metadata in the schema
+        # (some metadata gets auto-generated to help pandas deserialise better, we want to keep that)
+        t = pyarrow.Table.from_pandas(df)
+        new_metadata = {
+            b"owid_table": self.metadata.to_json(),  # type: ignore
+            b"owid_fields": json.dumps(self._get_fields_as_dict()),
+            **t.schema.metadata,
+        }
+        schema = t.schema.with_metadata(new_metadata)
+        t = t.cast(schema)
+
+        # write the combined table to disk
+        pq.write_table(t, path)
+
     def _save_metadata(self, filename: str) -> None:
         # write metadata
         with open(filename, "w") as ostream:
             metadata = self.metadata.to_dict()  # type: ignore
             metadata["primary_key"] = self.primary_key
-            metadata["fields"] = {
-                col: self._fields[col].to_dict() for col in self.all_columns
-            }
+            metadata["fields"] = self._get_fields_as_dict()
             json.dump(metadata, ostream, indent=2, default=str)
 
     @classmethod
-    def read_csv(cls, path: str) -> "Table":
+    def read_csv(cls, path: Union[str, Path]) -> "Table":
         """
         Read the table from csv plus accompanying JSON sidecar.
         """
+        if isinstance(path, Path):
+            path = path.as_posix()
+
         if not path.endswith(".csv"):
             raise ValueError(f'filename must end in ".csv": {path}')
 
@@ -187,10 +218,15 @@ class Table(pd.DataFrame):
         return t
 
     @classmethod
-    def read_feather(cls, path: str) -> "Table":
+    def read_feather(cls, path: Union[str, Path]) -> "Table":
         """
         Read the table from feather plus accompanying JSON sidecar.
+
+        The path may be a local file path or a URL.
         """
+        if isinstance(path, Path):
+            path = path.as_posix()
+
         if not path.endswith(".feather"):
             raise ValueError(f'filename must end in ".feather": {path}')
 
@@ -204,14 +240,46 @@ class Table(pd.DataFrame):
         fields = metadata.pop("fields") if "fields" in metadata else {}
 
         df.metadata = TableMeta.from_dict(metadata)
-        df._fields = defaultdict(
-            VariableMeta, {k: VariableMeta.from_dict(v) for k, v in fields.items()}
-        )
+        df._set_fields_from_dict(fields)
 
         if primary_key:
             df.set_index(primary_key, inplace=True)
 
         return df
+
+    @classmethod
+    def read_parquet(cls, path: Union[str, Path]) -> "Table":
+        """
+        Read the table from feather plus accompanying JSON sidecar.
+
+        The path may be a local file path or a URL.
+        """
+        if isinstance(path, Path):
+            path = path.as_posix()
+
+        if not path.endswith(".parquet"):
+            raise ValueError(f'filename must end in ".parquet": {path}')
+
+        # load the data as a pyarrow table
+        t = pq.read_table(path)
+        df = Table(t.to_pandas())
+
+        # look for embedded table and field metadata in the table schema
+        if b"owid_table" in t.schema.metadata:
+            df.metadata = TableMeta.from_json(t.schema.metadata[b"owid_table"])  # type: ignore
+        if b"owid_fields" in t.schema.metadata:
+            fields = json.loads(t.schema.metadata[b"owid_fields"])
+            df._set_fields_from_dict(fields)
+
+        return df
+
+    def _get_fields_as_dict(self) -> Dict[str, Any]:
+        return {col: self._fields[col].to_dict() for col in self.all_columns}
+
+    def _set_fields_from_dict(self, fields: Dict[str, Any]) -> None:
+        self._fields = defaultdict(
+            VariableMeta, {k: VariableMeta.from_dict(v) for k, v in fields.items()}
+        )
 
     @staticmethod
     def _read_metadata(data_path: str) -> Dict[str, Any]:

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -135,8 +135,8 @@ class Table(pd.DataFrame):
         # (some metadata gets auto-generated to help pandas deserialise better, we want to keep that)
         t = pyarrow.Table.from_pandas(df)
         new_metadata = {
-            b"owid_table": self.metadata.to_json(),  # type: ignore
-            b"owid_fields": json.dumps(self._get_fields_as_dict()),
+            b"owid_table": json.dumps(self.metadata.to_dict(), default=str),  # type: ignore
+            b"owid_fields": json.dumps(self._get_fields_as_dict(), default=str),
             **t.schema.metadata,
         }
         schema = t.schema.with_metadata(new_metadata)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -80,6 +80,8 @@ def test_add_table():
         # check that it's really on disk
         table_files = [
             join(dirname, t.metadata.checked_name + ".feather"),
+            join(dirname, t.metadata.checked_name + ".csv"),
+            join(dirname, t.metadata.checked_name + ".parquet"),
             join(dirname, t.metadata.checked_name + ".meta.json"),
         ]
         for filename in table_files:
@@ -112,6 +114,30 @@ def test_add_table_csv():
         ]
         for filename in table_files:
             assert exists(filename)
+
+        # load a fresh copy from disk
+        t2 = ds[t.metadata.checked_name]
+        assert id(t2) != id(t)
+
+        # the fresh copy from disk should be identical to the copy we added
+        assert t2.equals_table(t)
+
+
+def test_add_table_parquet():
+    t = mock_table()
+
+    with temp_dataset_dir() as dirname:
+        # make a dataset
+        ds = Dataset.create_empty(dirname)
+
+        # add the table, it should be on disk now
+        ds.add(t, formats=["parquet"])
+
+        # check that it's really on disk
+        assert exists(join(dirname, t.metadata.checked_name + ".parquet"))
+
+        # reaffirm that metadata is not coming from a JSON file
+        assert not exists(join(dirname, t.metadata.checked_name + ".meta.json"))
 
         # load a fresh copy from disk
         t2 = ds[t.metadata.checked_name]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -80,7 +80,6 @@ def test_add_table():
         # check that it's really on disk
         table_files = [
             join(dirname, t.metadata.checked_name + ".feather"),
-            join(dirname, t.metadata.checked_name + ".csv"),
             join(dirname, t.metadata.checked_name + ".parquet"),
             join(dirname, t.metadata.checked_name + ".meta.json"),
         ]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -103,7 +103,7 @@ def test_add_table_csv():
         ds = Dataset.create_empty(dirname)
 
         # add the table, it should be on disk now
-        ds.add(t, format="csv")
+        ds.add(t, formats=["csv"])
 
         # check that it's really on disk
         table_files = [


### PR DESCRIPTION
Parquet is an efficient columnar format like Feather. We want to support both and render to both since some downstream consumers only support one of these formats, and Parquet is better supported than Feather generally.

Parquet supports a schema with additional metadata; we take advantage of that and serialise our table metadata into the schema on save, restoring it on write.

By default, we also change Dataset so that when you add a table, it serialises the table to all available formats including CSV unless specifically restricted.
