### PR TITLE
fix: more throughly support parquet

### DIFF
--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -22,8 +22,9 @@ from . import utils
 
 FileFormat = Literal["csv", "feather", "parquet"]
 
-# the formats we can serialise and deserialise
-SUPPORTED_FORMATS: List[FileFormat] = ["csv", "feather", "parquet"]
+# the formats we can serialise and deserialise; in some cases they
+# will be tried in this order if we don't specify one explicitly
+SUPPORTED_FORMATS: List[FileFormat] = ["feather", "parquet", "csv"]
 
 # the formats we generate by default
 DEFAULT_FORMATS: List[FileFormat] = ["feather", "parquet"]
@@ -34,7 +35,7 @@ PREFERRED_FORMAT: FileFormat = "feather"
 # sanity checks
 assert set(DEFAULT_FORMATS).issubset(SUPPORTED_FORMATS)
 assert PREFERRED_FORMAT in DEFAULT_FORMATS
-assert PREFERRED_FORMAT in SUPPORTED_FORMATS
+assert SUPPORTED_FORMATS[0] == PREFERRED_FORMAT
 
 
 @dataclass

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -64,6 +64,38 @@ class Table(pd.DataFrame):
     def primary_key(self) -> List[str]:
         return [n for n in self.index.names if n]
 
+    def to(self, path: Union[str, Path]) -> None:
+        if isinstance(path, Path):
+            path = path.as_posix()
+
+        if path.endswith(".csv"):
+            return self.to_csv(path)
+
+        elif path.endswith(".feather"):
+            return self.to_feather(path)
+
+        elif path.endswith(".parquet"):
+            return self.to_parquet(path)
+
+        else:
+            raise ValueError(f"could not detect a suitable format to save to: {path}")
+
+    @classmethod
+    def read(cls, path: Union[str, Path]) -> "Table":
+        if isinstance(path, Path):
+            path = path.as_posix()
+
+        if path.endswith(".csv"):
+            return cls.read_csv(path)
+
+        elif path.endswith(".feather"):
+            return cls.read_feather(path)
+
+        elif path.endswith(".parquet"):
+            return cls.read_parquet(path)
+
+        raise ValueError(f"could not detect a suitable format to read from: {path}")
+
     # Mypy complaints about this not matching the defintiion of NDFrame.to_csv but I don't understand why
     def to_csv(self, path: Any, **kwargs: Any) -> None:  # type: ignore
         """

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -309,7 +309,8 @@ class Table(pd.DataFrame):
             df._set_fields_from_dict(fields)
         if b"primary_key" in t.schema.metadata:
             primary_key = json.loads(t.schema.metadata[b"primary_key"])
-            df.set_index(primary_key, inplace=True)
+            if primary_key:
+                df.set_index(primary_key, inplace=True)
 
         return df
 

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -65,6 +65,9 @@ class Table(pd.DataFrame):
         return [n for n in self.index.names if n]
 
     def to(self, path: Union[str, Path], repack: bool = True) -> None:
+        """
+        Save this table in one of our SUPPORTED_FORMATS.
+        """
         if isinstance(path, Path):
             path = path.as_posix()
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -30,12 +30,14 @@ def test_create_empty():
     with temp_dataset_dir(create=True) as dirname:
         shutil.rmtree(dirname)
 
-        Dataset.create_empty(dirname)
+        ds = Dataset.create_empty(dirname)
 
         assert exists(join(dirname, "index.json"))
         with open(join(dirname, "index.json")) as istream:
             doc = json.load(istream)
         assert doc == {"is_public": True}
+
+        assert len(ds.index()) == 0
 
 
 def test_create_empty_with_metadata(tmpdir):
@@ -85,6 +87,11 @@ def test_add_table():
         ]
         for filename in table_files:
             assert exists(filename)
+
+        # check other methods on Dataset
+        assert len(ds) == 1
+        assert len(ds.index()) == 1
+        assert t.metadata.checked_name in ds
 
         # load a fresh copy from disk
         t2 = ds[t.metadata.checked_name]

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -2,7 +2,7 @@
 #  test_tables.py
 #
 
-from typing import Literal
+from owid.catalog.datasets import FileFormat
 from owid.catalog.variables import Variable
 import tempfile
 from os.path import join, exists, splitext
@@ -86,49 +86,39 @@ def test_saving_empty_table_fails():
 
 
 # The parametrize decorator runs this test multiple times with different formats
-@pytest.mark.parametrize("format", ["csv", "feather"])
-def test_round_trip_no_metadata(format: Literal["csv", "feather"]) -> None:
+@pytest.mark.parametrize("format", ["csv", "feather", "parquet"])
+def test_round_trip_no_metadata(format: FileFormat) -> None:
     t1 = Table({"gdp": [100, 102, 104, 100], "countries": ["AU", "SE", "NA", "💡"]})
     with tempfile.TemporaryDirectory() as path:
         filename = join(path, f"table.{format}")
-        if format == "feather":
-            t1.to_feather(filename)
-        else:
-            t1.to_csv(filename)
+        t1.to(filename)
 
         assert exists(filename)
-        assert exists(splitext(filename)[0] + ".meta.json")
+        if format in ["csv", "feather"]:
+            assert exists(splitext(filename)[0] + ".meta.json")
 
-        if format == "feather":
-            t2 = Table.read_feather(filename)
-        else:
-            t2 = Table.read_csv(filename)
+        t2 = Table.read(filename)
         assert_tables_eq(t1, t2)
 
 
-@pytest.mark.parametrize("format", ["csv", "feather"])
-def test_round_trip_with_index(format: Literal["csv", "feather"]) -> None:
+@pytest.mark.parametrize("format", ["csv", "feather", "parquet"])
+def test_round_trip_with_index(format: FileFormat) -> None:
     t1 = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "NA"]})
     t1.set_index("country", inplace=True)
     with tempfile.TemporaryDirectory() as path:
         filename = join(path, f"table.{format}")
-        if format == "feather":
-            t1.to_feather(filename)
-        else:
-            t1.to_csv(filename)
+        t1.to(filename)
 
         assert exists(filename)
-        assert exists(splitext(filename)[0] + ".meta.json")
+        if format in ["csv", "feather"]:
+            assert exists(splitext(filename)[0] + ".meta.json")
 
-        if format == "feather":
-            t2 = Table.read_feather(filename)
-        else:
-            t2 = Table.read_csv(filename)
+        t2 = Table.read(filename)
         assert_tables_eq(t1, t2)
 
 
-@pytest.mark.parametrize("format", ["csv", "feather"])
-def test_round_trip_with_metadata(format: Literal["csv", "feather"]) -> None:
+@pytest.mark.parametrize("format", ["csv", "feather", "parquet"])
+def test_round_trip_with_metadata(format: FileFormat) -> None:
     t1 = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "NA"]})
     t1.set_index("country", inplace=True)
     t1.title = "A very special table"
@@ -136,18 +126,13 @@ def test_round_trip_with_metadata(format: Literal["csv", "feather"]) -> None:
 
     with tempfile.TemporaryDirectory() as path:
         filename = join(path, f"table.{format}")
-        if format == "feather":
-            t1.to_feather(filename)
-        else:
-            t1.to_csv(filename)
+        t1.to(filename)
 
         assert exists(filename)
-        assert exists(splitext(filename)[0] + ".meta.json")
+        if format in ["csv", "feather"]:
+            assert exists(splitext(filename)[0] + ".meta.json")
 
-        if format == "feather":
-            t2 = Table.read_feather(filename)
-        else:
-            t2 = Table.read_csv(filename)
+        t2 = Table.read(filename)
         assert_tables_eq(t1, t2)
 
 


### PR DESCRIPTION
Fixes #57

- Increase test coverage over parquet
- Fix edge case where parquet could not deserialise a table with no primary key
- Make use of generic `read_frame()` and `save_frame()` methods to avoid doing format detection everywhere
- Introduce a `PREFERRED_FORMAT` setting, which is currently `feather`
- Indicate in the static catalog all the formats that are supported for a table
- Clean up documentation across the board
