### PR TITLE
fix: a bug in find() channel filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ t = Table.read_csv('/tmp/my_table.csv')
 - `master`
   - Sort imports with `isort`
   - Change black line length to 120
+  - Fix a bug in channel filtering with the `find()` method
 - `v0.3.0`
   - Update `OWID_CATALOG_VERSION` to 3
   - Support multiple formats per table

--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -57,7 +57,7 @@ class CatalogMixin:
         namespace: Optional[str] = None,
         version: Optional[str] = None,
         dataset: Optional[str] = None,
-        channel: Optional[CHANNEL] = None,
+        channels: Optional[Iterable[CHANNEL]] = None,
     ) -> "CatalogFrame":
         criteria: npt.ArrayLike = np.ones(len(self.frame), dtype=bool)
 
@@ -73,12 +73,13 @@ class CatalogMixin:
         if dataset:
             criteria &= self.frame.dataset == dataset
 
-        if channel:
-            if channel not in self.channels:
-                raise ValueError(
-                    f"You need to add `{channel}` to channels in Catalog init (only `{self.channels}` are loaded now)"
-                )
-            criteria &= self.frame.channel == channel
+        if channels:
+            for channel in channels:
+                if channel not in self.channels:
+                    raise ValueError(
+                        f"You need to add `{channel}` to channels in Catalog init (only `{self.channels}` are loaded now)"
+                    )
+            criteria &= self.frame.channel.isin(channels)
 
         matches = self.frame[criteria]
         if "checksum" in matches.columns:
@@ -367,7 +368,7 @@ def find(
     if not REMOTE_CATALOG:
         REMOTE_CATALOG = RemoteCatalog(channels=channels)
 
-    return REMOTE_CATALOG.find(table=table, namespace=namespace, version=version, dataset=dataset)
+    return REMOTE_CATALOG.find(table=table, namespace=namespace, version=version, dataset=dataset, channels=channels)
 
 
 def find_one(*args: Optional[str], **kwargs: Optional[str]) -> Table:

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -64,6 +64,11 @@ def test_local_default_channel():
         assert set(catalog.find().channel) == {"garden", "meadow"}
 
 
+def test_local_select_catalog():
+    with mock_catalog(1, channels=("garden", "meadow")) as catalog:
+        assert set(catalog.find(channels=["meadow"]).channel) == {"meadow"}
+
+
 def test_calling_find_adds_channels():
     find("abc")
     from owid.catalog.catalogs import REMOTE_CATALOG


### PR DESCRIPTION
When you had a catalog in memory already, `CatalogMixin.find()` was not filtering your channel selection, but was always returning all channels.

Minor API change: in-memory find now accepts `channels` rather than a single `channel`, mirroring the global method.
