### PR TITLE
enhance(catalog): improve error messaging and table matching

### DIFF
--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -62,7 +62,7 @@ class CatalogMixin:
         criteria: npt.ArrayLike = np.ones(len(self.frame), dtype=bool)
 
         if table:
-            criteria &= self.frame.table.apply(lambda t: table in t)
+            criteria &= self.frame.table.str.contains(table)
 
         if namespace:
             criteria &= self.frame.namespace == namespace
@@ -298,8 +298,10 @@ class CatalogFrame(pd.DataFrame):
     def load(self) -> Table:
         if len(self) == 1:
             return self.iloc[0].load()  # type: ignore
-
-        raise ValueError("only one table can be loaded at once")
+        elif len(self) == 0:
+            raise ValueError("no tables found")
+        else:
+            raise ValueError(f"only one table can be loaded at once (tables found: {', '.join(self.table.tolist())})")
 
     @staticmethod
     def create_empty() -> "CatalogFrame":

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -374,7 +374,10 @@ class Table(pd.DataFrame):
         return combined
 
     def update_metadata_from_yaml(self, path: Union[Path, str], table_name: str) -> None:
-        """Update metadata of table and variables from a YAML file."""
+        """Update metadata of table and variables from a YAML file.
+        :param path: Path to YAML file.
+        :param table_name: Name of table, also updates this in the metadata.
+        """
         with open(path) as istream:
             annot = yaml.safe_load(istream)
 


### PR DESCRIPTION
Using `table.str.contains` lets us use regular expressions which are useful for tools like `compare` (we had two tables `faostat_ek` and `faostat_ek_flat` which can now be matched with `faostat_ek$`).

Needed by https://github.com/owid/etl/pull/452