### PR TITLE
feature: get a table with catalog[path] syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ t = Table.read_csv('/tmp/my_table.csv')
   - Sort imports with `isort`
   - Change black line length to 120
   - Add `grapher` channel
+  - Support path-based indexing into catalogs
 - `v0.3.0`
   - Update `OWID_CATALOG_VERSION` to 3
   - Support multiple formats per table

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -36,7 +36,13 @@ def test_remote_find_returns_all():
 
 def test_remote_find_one():
     c = load_catalog()
-    t = c.find_one("population", dataset="key_indicators", namespace="owid")
+    t = c.find_one("population_density", dataset="key_indicators", namespace="owid")
+    assert isinstance(t, Table)
+
+
+def test_remote_getitem():
+    c = load_catalog()
+    t = c["garden/owid/latest/key_indicators/population_density"]
     assert isinstance(t, Table)
 
 
@@ -49,6 +55,13 @@ def test_find_from_local_catalog():
     with mock_catalog(3) as catalog:
         matches = catalog.find()
         assert len(matches.dataset.unique()) == 3
+
+
+def test_getitem_from_local_catalog():
+    with mock_catalog(1) as catalog:
+        path = catalog.find().iloc[0].path
+        t = catalog[path]
+        assert isinstance(t, Table)
 
 
 def test_load_from_local_catalog():


### PR DESCRIPTION
We typically use `find()` or `find_one()` for accessing into catalogs, even when we want something very specific.

There are two downsides to this:

1. These methods use substsring matching, so it can actually be impossible to uniquely specify a table this way
2. They have to load the entire catalog frame before giving you your data, even when the data itself is readily available

As an alternative, this change add path-based indexing into catalogs. For example, to get the `population` table:

```python
from owid import catalog
rc = catalog.RemoteCatalog()
pop = rc['garden/owid/latest/key_indicators/population']
```
