### PR TITLE
fix(tables): improve Table.copy performance

### DIFF
--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -3,6 +3,7 @@
 #
 
 import copy
+import dataclasses
 import json
 from collections import defaultdict
 from os.path import dirname, join, splitext
@@ -408,8 +409,13 @@ class Table(pd.DataFrame):
     def copy(self, deep: bool = True) -> "Table":
         """Copy table together with all its metadata."""
         tab = super().copy(deep=deep)
-        tab.metadata = copy.deepcopy(self.metadata)
-        tab._fields = copy.deepcopy(self._fields)
+
+        tab.metadata = dataclasses.replace(self.metadata)
+
+        for k, v in self._fields.items():
+            tab._fields[k] = dataclasses.replace(v)
+            tab._fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+
         return tab
 
     def reset_index(self, *args, **kwargs) -> "Table":  # type: ignore

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -412,9 +412,11 @@ class Table(pd.DataFrame):
 
         tab.metadata = dataclasses.replace(self.metadata)
 
+        new_fields = defaultdict(VariableMeta)
         for k, v in self._fields.items():
-            tab._fields[k] = dataclasses.replace(v)
-            tab._fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+            new_fields[k] = dataclasses.replace(v)
+            new_fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+        tab._fields = new_fields
 
         return tab
 


### PR DESCRIPTION
Copying with `dataclasses.replace` is much faster than deepcopy