### PR TITLE
fix(tables): fix copy_from_metadata if target table has incomplete _fields

### DIFF
--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -475,9 +475,14 @@ class Table(pd.DataFrame):
         # NOTE: copying with `dataclasses.replace` is much faster than `copy.deepcopy`
         new_fields = defaultdict(VariableMeta)
         for k in common_columns:
-            v = table._fields[k]
-            new_fields[k] = dataclasses.replace(v)
-            new_fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+            # copy if we have metadata in the other table
+            if k in table._fields:
+                v = table._fields[k]
+                new_fields[k] = dataclasses.replace(v)
+                new_fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+            # otherwise keep current metadata (if it exists)
+            elif k in self._fields:
+                new_fields[k] = self._fields[k]
         self._fields = new_fields
 
     def reset_index(self, *args, **kwargs) -> "Table":  # type: ignore

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -279,13 +279,15 @@ def test_copy() -> None:
 
 
 def test_copy_metadata_from() -> None:
-    t: Table = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "CH"]}).set_index("country")  # type: ignore
+    t: Table = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "CH"]})
     t.metadata.title = "GDP table"
     t.gdp.metadata.title = "GDP"
 
     t2: Table = Table(pd.DataFrame(t))
+    t2.country.metadata.title = "Country"
+
     t2.copy_metadata_from(t)
 
     assert t2.gdp.metadata.title == "GDP"
+    assert t2.country.metadata.title == "Country"
     assert t2.metadata.title == "GDP table"
-    assert t2.primary_key == ["country"]


### PR DESCRIPTION
There was an error in ETL in case metadata of target table is incomplete. Fixed it and modified the test to catch this.