### PR TITLE
fix(dataset): bool(dataset) should be True even if it doesn't have any tables

### DIFF
--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -189,6 +189,9 @@ class Dataset:
     def _index_file(self) -> str:
         return join(self.path, "index.json")
 
+    def __bool__(self) -> bool:
+        return True
+
     def __len__(self) -> int:
         return len(self.table_names)
 


### PR DESCRIPTION
`bool(dataset)` looks at its `__len__()` and if it is empty, it returns False. I think it should always return True so that we can safely do `if dataset` for optional arguments (this bit me a bit).