### PR TITLE
feat(catalog): Let find_latest ingest version as an argument

### DIFF
--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -402,10 +402,12 @@ def find_latest(
     namespace: Optional[str] = None,
     dataset: Optional[str] = None,
     channels: Iterable[CHANNEL] = ("garden",),
+    version: Optional[str] = None,
 ) -> Table:
     REMOTE_CATALOG = _load_remote_catalog(channels=channels)
 
-    return REMOTE_CATALOG.find_latest(table=table, namespace=namespace, dataset=dataset)
+    # If version is not specified, it will find the latest version given all other specifications.
+    return REMOTE_CATALOG.find_latest(table=table, namespace=namespace, dataset=dataset, version=version)
 
 
 def _download_private_file(uri: str, tmpdir: str) -> str:


### PR DESCRIPTION
Small change: I think it's convenient if `find_latest` can ingest `version`. It finds the latest version of a dataset, given the specifications (if you specify the version, well, that's still the latest version). With this, we can basically replace `find_one` by `find_latest`, if we want to load either a specific version, or otherwise the latest.