### PR TITLE
enhance(datasetmeta): add channel to DatasetMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ t = Table.read_csv('/tmp/my_table.csv')
 - `dev`
   - Remove `catalog.frames`; use `owid-repack` package instead
   - Relax dependency constraints
+  - Add optional `channel` argument to `DatasetMeta`
 - `v0.3.4`
   - Bump `pyarrow` dependency to enable Python 3.11 support
 - `v0.3.3`

--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -9,7 +9,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Union, cast
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union, cast
 from urllib.parse import urlparse
 
 import numpy as np

--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -19,7 +19,7 @@ import requests
 import structlog
 
 from . import s3_utils
-from .datasets import PREFERRED_FORMAT, SUPPORTED_FORMATS, Dataset, FileFormat
+from .datasets import CHANNEL, PREFERRED_FORMAT, SUPPORTED_FORMATS, Dataset, FileFormat
 from .tables import Table
 
 log = structlog.get_logger()
@@ -35,9 +35,6 @@ S3_OWID_URI = "s3://owid-catalog"
 
 # global copy cached after first request
 REMOTE_CATALOG: Optional["RemoteCatalog"] = None
-
-# available channels in the catalog
-CHANNEL = Literal["garden", "meadow", "grapher", "backport", "open_numbers", "examples", "explorers"]
 
 # what formats should we for our index of available datasets?
 INDEX_FORMATS: List[FileFormat] = ["feather", "parquet"]

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -37,6 +37,9 @@ assert set(DEFAULT_FORMATS).issubset(SUPPORTED_FORMATS)
 assert PREFERRED_FORMAT in DEFAULT_FORMATS
 assert SUPPORTED_FORMATS[0] == PREFERRED_FORMAT
 
+# available channels in the catalog
+CHANNEL = Literal["garden", "meadow", "grapher", "backport", "open_numbers", "examples", "explorers"]
+
 
 @dataclass
 class Dataset:
@@ -126,8 +129,11 @@ class Dataset:
         # determine channel automatically from path
         # NOTE: shouldn't we force channel/namespace/version/short_name to be filled from path?
         # see https://github.com/owid/owid-catalog-py/pull/79#issue-1507959097 for discussion
-        channel, _, _, _ = str(self.path).split("/")[-4:]
-        self.metadata.channel = channel
+        parts = str(self.path).split("/")
+        if len(parts) >= 4:
+            channel, _, _, _ = parts[-4:]
+            if channel in CHANNEL.__args__:
+                self.metadata.channel = channel
 
         self.metadata.save(self._index_file)
 

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -125,6 +125,7 @@ class Dataset:
 
         # determine channel automatically from path
         # NOTE: shouldn't we force channel/namespace/version/short_name to be filled from path?
+        # see https://github.com/owid/owid-catalog-py/pull/79#issue-1507959097 for discussion
         channel, _, _, _ = str(self.path).split("/")[-4:]
         self.metadata.channel = channel
 

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -123,6 +123,11 @@ class Dataset:
         if not self.metadata.namespace:
             warnings.warn(f"Dataset {self.metadata.short_name} is missing namespace")
 
+        # determine channel automatically from path
+        # NOTE: shouldn't we force channel/namespace/version/short_name to be filled from path?
+        channel, _, _, _ = str(self.path).split("/")[-4:]
+        self.metadata.channel = channel
+
         self.metadata.save(self._index_file)
 
         # Update the copy of this datasets metadata in every table in the set.

--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -132,7 +132,7 @@ class Dataset:
         parts = str(self.path).split("/")
         if len(parts) >= 4:
             channel, _, _, _ = parts[-4:]
-            if channel in CHANNEL.__args__:
+            if channel in CHANNEL.__args__:  # type: ignore
                 self.metadata.channel = channel
 
         self.metadata.save(self._index_file)

--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -126,6 +126,7 @@ class DatasetMeta:
     the variable level.
     """
 
+    channel: Optional[str] = None
     namespace: Optional[str] = None
     # NOTE: short_name should be underscore and validate in setter, however this
     # is nontrivial to do with `dataclass_json` (see https://github.com/lidatong/dataclasses-json/issues/176)
@@ -199,6 +200,15 @@ class DatasetMeta:
         for k, v in annot["dataset"].items():
             if k != "sources":
                 setattr(self, k, v)
+
+    @property
+    def uri(self) -> str:
+        """Return unique URI for this dataset if"""
+        assert self.channel, "DatasetMeta.channel is not set"
+        assert self.namespace, "DatasetMeta.namespace is not set"
+        assert self.version, "DatasetMeta.version is not set"
+        assert self.short_name, "DatasetMeta.short_name is not set"
+        return f"{self.channel}/{self.namespace}/{self.version}/{self.short_name}"
 
 
 @pruned_json

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -15,7 +15,6 @@ from typing import Any, Iterator, Optional, Union
 
 import pytest
 import yaml
-
 from owid.catalog import Dataset, DatasetMeta
 
 from .mocking import mock
@@ -269,6 +268,19 @@ def test_save_fills_channel(tmp_path: Path):
 
     d2 = Dataset(path)
     assert d2.metadata.channel == "garden"
+
+
+def test_save_without_valid_channel(tmp_path: Path):
+    path = tmp_path / "invalid/owid/latest/shortname"
+    path.parent.mkdir(exist_ok=True, parents=True)
+
+    d = Dataset.create_empty(path)
+    d.metadata = mock(DatasetMeta)
+    d.metadata.channel = None
+    d.save()
+
+    d2 = Dataset(path)
+    assert d2.metadata.channel is None
 
 
 @contextmanager

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -15,6 +15,7 @@ from typing import Any, Iterator, Optional, Union
 
 import pytest
 import yaml
+
 from owid.catalog import Dataset, DatasetMeta
 
 from .mocking import mock

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -15,7 +15,6 @@ from typing import Any, Iterator, Optional, Union
 
 import pytest
 import yaml
-
 from owid.catalog import Dataset, DatasetMeta
 
 from .mocking import mock
@@ -257,6 +256,18 @@ def test_update_metadata(tmp_path):
 def test_bool():
     with mock_dataset(n_tables=0) as d:
         assert bool(d)
+
+
+def test_save_fills_channel(tmp_path: Path):
+    path = tmp_path / "garden/owid/latest/shortname"
+    path.parent.mkdir(exist_ok=True, parents=True)
+
+    d = Dataset.create_empty(path)
+    d.metadata = mock(DatasetMeta)
+    d.save()
+
+    d2 = Dataset(path)
+    assert d2.metadata.channel == "garden"
 
 
 @contextmanager


### PR DESCRIPTION
I'd have found channel really useful when working on ETL tools. This PR adds `channel` to `DatasetMeta` and automatically fills it when saving the dataset.

This opens up a question - should we assume that all datasets will be saved with `[channel]/[namespace]/[version]/[short_name]` directory structure and implicitly set all these attributes? That would give us unique `uri` for every dataset. It's not very common, but I think there are some datasets with some of these attributes missing. It might also slightly simplify our code. I can't think of many uses cases for non-structured arbitrary paths besides somehow easier testing. To be fair, I don't think we gain much from this refactoring, perhaps it's better to keep status quo and keep this in the back of our heads.