### PR TITLE
enhance(parquet): move metadata to fields from table

### DIFF
--- a/owid/catalog/catalogs.py
+++ b/owid/catalog/catalogs.py
@@ -59,6 +59,10 @@ class CatalogMixin:
     ) -> "CatalogFrame":
         criteria: npt.ArrayLike = np.ones(len(self.frame), dtype=bool)
 
+        # someone can pass integers as versions
+        if version is not None and not isinstance(version, str):
+            version = str(version)
+
         if table:
             criteria &= self.frame.table.str.contains(table)
 
@@ -386,7 +390,6 @@ def find(
     channels: Iterable[CHANNEL] = ("garden",),
 ) -> "CatalogFrame":
     REMOTE_CATALOG = _load_remote_catalog(channels=channels)
-
     return REMOTE_CATALOG.find(table=table, namespace=namespace, version=version, dataset=dataset)
 
 

--- a/owid/catalog/variables.py
+++ b/owid/catalog/variables.py
@@ -11,7 +11,8 @@ import pandas as pd
 from .meta import VariableMeta
 from .properties import metadata_property
 
-SCHEMA = json.load(open(path.join(path.dirname(__file__), "schemas", "table.json")))
+with open(path.join(path.dirname(__file__), "schemas", "table.json")) as f:
+    SCHEMA = json.load(f)
 METADATA_FIELDS = list(SCHEMA["properties"])
 
 


### PR DESCRIPTION
We save metadata of all fields into `table.schema.metadata[b"owid_fields"]`. Move this metadata to fields, i.e. `table.field('mycolumn').metadata`. This was supposed to be a fix for this [performance issue with parquet files](https://github.com/owid/etl/issues/783), but unfortunately it didn't solve it.

There's no added value from this PR besides refactoring fields metadata, so probably not worth merging yet.