### PR TITLE
fix(tables): dont save metadata to parquet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ t = Table.read_csv('/tmp/my_table.csv')
   - Remove `catalog.frames`; use `owid-repack` package instead
   - Relax dependency constraints
   - Add optional `channel` argument to `DatasetMeta`
+  - Stop supporting metadata in Parquet format, load JSON sidecar instead
 - `v0.3.4`
   - Bump `pyarrow` dependency to enable Python 3.11 support
 - `v0.3.3`

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -226,6 +226,8 @@ class Table(pd.DataFrame):
         # write the combined table to disk
         pq.write_table(t, path)
 
+        self._save_metadata(self.metadata_filename(path))
+
     def _save_metadata(self, filename: str) -> None:
         # write metadata
         with open(filename, "w") as ostream:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -144,8 +144,8 @@ def test_add_table_parquet():
         # check that it's really on disk
         assert exists(join(dirname, t.metadata.checked_name + ".parquet"))
 
-        # reaffirm that metadata is not coming from a JSON file
-        assert not exists(join(dirname, t.metadata.checked_name + ".meta.json"))
+        # metadata exists as a sidecar JSON
+        assert exists(join(dirname, t.metadata.checked_name + ".meta.json"))
 
         # load a fresh copy from disk
         t2 = ds[t.metadata.checked_name]


### PR DESCRIPTION
Reading parquet format is [inefficient with lots of metadata](https://github.com/owid/etl/issues/783). Stop saving it to parquet and use JSON sidecar instead just like we do it for feather.