### PR TITLE
enhance(meta): optional metadata fields

### DIFF
--- a/owid/catalog/datasets.py
+++ b/owid/catalog/datasets.py
@@ -158,7 +158,7 @@ class Dataset:
 
         with open(metadata_path) as istream:
             metadata = yaml.safe_load(istream)
-            for table_name in metadata["tables"].keys():
+            for table_name in metadata.get("tables", {}).keys():
                 table = self[table_name]
                 table.update_metadata_from_yaml(metadata_path, table_name)
                 table._save_metadata(join(self.path, table.metadata.checked_name + ".meta.json"))

--- a/owid/catalog/meta.py
+++ b/owid/catalog/meta.py
@@ -175,7 +175,7 @@ class DatasetMeta:
         with open(path) as istream:
             annot = yaml.safe_load(istream)
 
-        dataset_sources = annot["dataset"].get("sources", []) or []
+        dataset_sources = annot.get("dataset", {}).get("sources", []) or []
 
         # update sources of dataset, if there are no sources in the new dataset, don't update existing ones
         if if_source_exists == "replace" and dataset_sources:
@@ -197,7 +197,7 @@ class DatasetMeta:
         self.sources.extend(new_sources)
 
         # update dataset
-        for k, v in annot["dataset"].items():
+        for k, v in annot.get("dataset", {}).items():
             if k != "sources":
                 setattr(self, k, v)
 


### PR DESCRIPTION
Make things like `dataset: {}` in metadata unnecessary.