### PR TITLE
fix(catalog): Avoid ValueError when adding a Table column as an opera…

### DIFF
--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -368,7 +368,12 @@ class Table(pd.DataFrame):
         # propagate metadata when we add a series to a table
         if isinstance(key, str):
             if isinstance(value, variables.Variable):
-                self._fields[key] = value.metadata
+                try:
+                    self._fields[key] = value.metadata
+                except ValueError:
+                    # This error is raised e.g. when creating a new variable which is an operation between two other
+                    # existing columns in the table.
+                    self._fields[key] = VariableMeta()
             else:
                 self._fields[key] = VariableMeta()
 


### PR DESCRIPTION
Avoid ValueError when adding a Table column as an operation of other columns.

I think the main issue that we encounter when working with Tables is that, when creating a new column as an operation of other two columns, an error is raised. For example:
```
tb = Table({"a": [1, 2, 3], "b": [4,5,6]})
tb["c"] = tb["a"] + tb["b"]
```
raises a `ValueError`.

I think this may be the main reason why we can't use `Tables`. So fixing it would let us keep working with tables without needing to move back and forth to dataframes.

I haven't looked into the reason why this happens, but simply excepted the error. I don't know if there's some underlying reason why the error should be raised.

As a sanity check I have run a few small and big steps (e.g. `aviation_statistics` and `energy_mix`, where the error would happen) and after doing this fix, `etl-datadiff` showed that nothing changed.