### PR TITLE
fix(Tables): do not modify fields if name is None to fix pandas add operation

### DIFF
--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -368,12 +368,10 @@ class Table(pd.DataFrame):
         # propagate metadata when we add a series to a table
         if isinstance(key, str):
             if isinstance(value, variables.Variable):
-                try:
-                    self._fields[key] = value.metadata
-                except ValueError:
-                    # This error is raised e.g. when creating a new variable which is an operation between two other
-                    # existing columns in the table.
-                    self._fields[key] = VariableMeta()
+                # variable needs to be assigned name to make VariableMeta work
+                if not value.name:
+                    value.name = key
+                self._fields[key] = value.metadata
             else:
                 self._fields[key] = VariableMeta()
 

--- a/owid/catalog/variables.py
+++ b/owid/catalog/variables.py
@@ -40,13 +40,15 @@ class Variable(pd.Series):
 
     @name.setter
     def name(self, name: str) -> None:
-        # move metadata when you rename a field
-        if self._name and self._name in self._fields:
-            self._fields[name] = self._fields.pop(self._name)
+        # None name does not modify _fields, it is usually triggered on pandas operations
+        if name is not None:
+            # move metadata when you rename a field
+            if self._name and self._name in self._fields:
+                self._fields[name] = self._fields.pop(self._name)
 
-        # make sure there is always a placeholder metadata object
-        if name not in self._fields:
-            self._fields[name] = VariableMeta()
+            # make sure there is always a placeholder metadata object
+            if name not in self._fields:
+                self._fields[name] = VariableMeta()
 
         self._name = name
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -303,6 +303,27 @@ def test_addition_with_metadata() -> None:
     t: Table = Table({"a": [1, 2], "b": [3, 4]})
     t.a.metadata.title = "A"
     t.b.metadata.title = "B"
-    # addition should not inherit metadata
+
     t["c"] = t["a"] + t["b"]
+
+    # addition should not inherit metadata
     assert t.c.metadata == VariableMeta()
+
+    t.c.metadata.title = "C"
+
+    # addition shouldn't change the metadata of the original columns
+    assert t.a.metadata.title == "A"
+    assert t.b.metadata.title == "B"
+    assert t.c.metadata.title == "C"
+
+
+def test_addition_same_variable() -> None:
+    t: Table = Table({"a": [1, 2], "b": [3, 4]})
+    t.a.metadata.title = "A"
+    t.b.metadata.title = "B"
+
+    t["a"] = t["a"] + t["b"]
+
+    # addition shouldn't change the metadata of the original columns
+    assert t.a.metadata.title == "A"
+    assert t.b.metadata.title == "B"


### PR DESCRIPTION
`t["c"] = t["a"] + t["b"]` was previously erasing metadata of `t["a"]`. This happened when pandas tried to set `name` to `None`. We thought it was renaming and we renamed variable `a` to `None` in `_fields` dictionary. This PR don't modify `_fields` when we try to set None name.