### PR TITLE
:bug: keep metadata when calling set_index -> reset_index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "python.formatting.provider": "none"
 }

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -8,7 +8,7 @@ import json
 from collections import defaultdict
 from os.path import dirname, join, splitext
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Union, cast, overload
 
 import pandas as pd
 import pyarrow
@@ -264,38 +264,6 @@ class Table(pd.DataFrame):
 
         return df
 
-    def set_index(  # type: ignore
-        self,
-        keys: Union[str, List[str]],
-        inplace: bool = False,
-        drop: bool = True,
-        append: bool = False,
-        verify_integrity: bool = False,
-    ) -> Optional[pd.DataFrame]:
-        if isinstance(keys, str):
-            keys = [keys]
-
-        if inplace:
-            super().set_index(
-                keys,
-                inplace=True,
-                drop=drop,
-                append=append,
-                verify_integrity=verify_integrity,
-            )
-            self.metadata.primary_key = keys
-            return None
-
-        t = super().set_index(
-            keys,
-            inplace=False,
-            drop=drop,
-            append=append,
-            verify_integrity=verify_integrity,
-        )
-        t.metadata.primary_key = keys
-        return t
-
     @classmethod
     def _add_metadata(cls, df: pd.DataFrame, path: str) -> None:
         """Read metadata from JSON sidecar and add it to the dataframe."""
@@ -482,9 +450,58 @@ class Table(pd.DataFrame):
                 new_fields[k] = self._fields[k]
         self._fields = new_fields
 
-    def reset_index(self, *args, **kwargs) -> "Table":  # type: ignore
+    @overload
+    def set_index(
+        self,
+        keys: Union[str, List[str]],
+        *,
+        inplace: Literal[True],
+    ) -> None:
+        ...
+
+    @overload
+    def set_index(self, keys: Union[str, List[str]], *, inplace: Literal[False]) -> "Table":
+        ...
+
+    @overload
+    def set_index(self, keys: Union[str, List[str]]) -> "Table":
+        ...
+
+    def set_index(
+        self,
+        keys: Union[str, List[str]],
+        **kwargs,
+    ) -> Optional["Table"]:
+        if isinstance(keys, str):
+            keys = [keys]
+
+        if kwargs.get("inplace"):
+            super().set_index(keys, **kwargs)
+            self.metadata.primary_key = keys
+            return None
+        else:
+            t = super().set_index(keys, **kwargs)
+            t.metadata.primary_key = keys
+            return cast(Table, t)
+
+    @overload
+    def reset_index(self, *, inplace: Literal[True]) -> None:
+        ...
+
+    @overload
+    def reset_index(self, *, inplace: Literal[False]) -> "Table":
+        ...
+
+    @overload
+    def reset_index(self) -> "Table":
+        ...
+
+    def reset_index(self, *args, **kwargs) -> Optional["Table"]:  # type: ignore
         """Fix type signature of reset_index."""
         t = super().reset_index(*args, **kwargs)
-        # preserve metadata in _fields, calling reset_index() on a table drops it
-        t._fields = self._fields
-        return t  # type: ignore
+        if kwargs.get("inplace"):
+            return None
+        else:
+            # preserve metadata in _fields, calling reset_index() on a table drops it
+            t._fields = self._fields
+            return t  # type: ignore

--- a/owid/catalog/tables.py
+++ b/owid/catalog/tables.py
@@ -484,4 +484,7 @@ class Table(pd.DataFrame):
 
     def reset_index(self, *args, **kwargs) -> "Table":  # type: ignore
         """Fix type signature of reset_index."""
-        return super().reset_index(*args, **kwargs)  # type: ignore
+        t = super().reset_index(*args, **kwargs)
+        # preserve metadata in _fields, calling reset_index() on a table drops it
+        t._fields = self._fields
+        return t  # type: ignore

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -335,7 +335,20 @@ def test_set_index_keeps_metadata() -> None:
     tb["b"].metadata.title = "B"
 
     tb_new = tb.set_index(["a"])
-    tb_new = tb_new.reset_index()  # type: ignore
+    tb_new = tb_new.reset_index()
+
+    # metadata should be preserved
+    assert tb_new["a"].metadata.title == "A"
+    assert tb_new["b"].metadata.title == "B"
+
+
+def test_set_index_keeps_metadata_inplace() -> None:
+    tb = Table(pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+    tb["a"].metadata.title = "A"
+    tb["b"].metadata.title = "B"
+
+    tb_new = tb.set_index(["a"])
+    tb_new.reset_index(inplace=True)
 
     # metadata should be preserved
     assert tb_new["a"].metadata.title == "A"

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -327,3 +327,16 @@ def test_addition_same_variable() -> None:
     # addition shouldn't change the metadata of the original columns
     assert t.a.metadata.title == "A"
     assert t.b.metadata.title == "B"
+
+
+def test_set_index_keeps_metadata() -> None:
+    tb = Table(pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
+    tb["a"].metadata.title = "A"
+    tb["b"].metadata.title = "B"
+
+    tb_new = tb.set_index(["a"])
+    tb_new = tb_new.reset_index()  # type: ignore
+
+    # metadata should be preserved
+    assert tb_new["a"].metadata.title == "A"
+    assert tb_new["b"].metadata.title == "B"


### PR DESCRIPTION
Fix for https://github.com/owid/owid-catalog-py/issues/81.

I'm not sure how well will this work in practice though. Pandas isn't keeping "metadata" by default when switching between index and column, so this is a bit of a hack.